### PR TITLE
Added omitted line that load 'extract-text-webpack-plugin' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ module.exports = {
 
 ```js
 // webpack.config.js
+
+// ...
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+// ...
 {
   // ...
   module: {


### PR DESCRIPTION
강의 중에는 디버깅 하셔서 추가 하셨지만, 강의자료만 봐도 혼동 없게 extract-text-webpack-plugin 모듈을 불러오는 라인을 추가 하였습니다.